### PR TITLE
Remove "Day" label and various other style tweaks

### DIFF
--- a/app.css
+++ b/app.css
@@ -32,6 +32,7 @@ input.enter-goal {
 
 button.enter-goal {
   width: 20%;
+  margin-top: 0;
 }
 
 .congrats img {

--- a/app.css
+++ b/app.css
@@ -9,15 +9,8 @@
 	padding-top: 10px;
 }
 
-.message, .days-label, .congrats {
+.message, .congrats {
   padding-bottom: 5px;
-}
-
-span.days {
-	font-size: .7em;
-	word-spacing: 6.6em;
-	position: relative;
-	left: 4.25em;
 }
 
 .progress {

--- a/app.css
+++ b/app.css
@@ -21,6 +21,10 @@
   background-color: #78A300;
 }
 
+.author-link {
+  margin-top: 10px;
+}
+
 input.enter-goal {
   padding: 1% 5px 1% 5px;
   width: 75%;

--- a/manifest.json
+++ b/manifest.json
@@ -9,5 +9,12 @@
   "private": false,
   "location": "ticket_sidebar",
   "version": "0.1.2",
-  "frameworkVersion": "1.0"
+  "frameworkVersion": "1.0",
+  "parameters": [
+    {
+      "name": "author-url",
+      "type": "hidden",
+      "default": "https://www.linkedin.com/in/josephpalmieri"
+    }
+  ]
 }

--- a/templates/congrats.hdbs
+++ b/templates/congrats.hdbs
@@ -6,6 +6,6 @@
   <img src='{{congratsImg}}'/>
 </div>
 <small class='pull-right author-link'>by
-  <a href='https://github.com/jpalmieri' target='_blank' class='muted'>{{author.name}}</a>
+  <a href="{{setting 'author-url'}}" target='_blank' class='muted'>{{author.name}}</a>
 </small>
 <button class='change-goal btn btn-success'>Change Goal</button>

--- a/templates/congrats.hdbs
+++ b/templates/congrats.hdbs
@@ -5,4 +5,7 @@
 <div class='congrats'>
   <img src='{{congratsImg}}'/>
 </div>
+<small class='pull-right author-link'>by
+  <a href='https://github.com/jpalmieri' target='_blank' class='muted'>{{author.name}}</a>
+</small>
 <button class='change-goal btn btn-success'>Change Goal</button>

--- a/templates/prog_bar.hdbs
+++ b/templates/prog_bar.hdbs
@@ -7,6 +7,6 @@
   <div class='bar' style='width: {{percentSolved}}%;'></div>
 </div>
 <small class='pull-right author-link'>by
-  <a href='https://github.com/jpalmieri' target='_blank' class='muted'>{{author.name}}</a>
+  <a href="{{setting 'author-url'}}" target='_blank' class='muted'>{{author.name}}</a>
 </small>
 <button class='change-goal btn btn-success'>Change Goal</button>

--- a/templates/prog_bar.hdbs
+++ b/templates/prog_bar.hdbs
@@ -6,7 +6,7 @@
 <div class='progress progress-striped'>
   <div class='bar' style='width: {{percentSolved}}%;'></div>
 </div>
-<small class='pull-right'>by
+<small class='pull-right author-link'>by
   <a href='https://github.com/jpalmieri' target='_blank' class='muted'>{{author.name}}</a>
 </small>
 <button class='change-goal btn btn-success'>Change Goal</button>

--- a/templates/prog_bar.hdbs
+++ b/templates/prog_bar.hdbs
@@ -6,9 +6,6 @@
 <div class='progress progress-striped'>
   <div class='bar' style='width: {{percentSolved}}%;'></div>
 </div>
-<div class='days-label'>
-  Day <span class='days'>1 2 3 4 5</span>
-</div>
 <small class='pull-right'>by
   <a href='https://github.com/jpalmieri' target='_blank' class='muted'>{{author.name}}</a>
 </small>


### PR DESCRIPTION
Zendesk seems to have done some style changes which broke the days label:

![image](https://cloud.githubusercontent.com/assets/4692673/19695409/02d820da-9a98-11e6-8658-6fa8013d47d4.png)

This doesn't seem to be that useful of a feature, so I'm going to remove the label entirely.

Also:
- add link to author's url on congrats view 
- add author url as a hidden parameter (not available in the settings UI) to keep it DRY
- adjust space around author link
