### PR TITLE
Allow admin to adjust work week

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@
     init: function() {
       // Validation for start day setting. Defaults to 1 (Monday).
       this.startDay = this.setting('start_day');
-      if (this.startDay < 0 || this.startDay > 6) { this.startDay = 1 }
+      if (this.startDay < 0 || this.startDay > 6) { this.startDay = 1; }
 
       if ( !this.store('goal') ){
         this.showEnterGoal();
@@ -101,9 +101,9 @@
       // daysSinceStartDay = 5 - 3, i.e., it's been 2 days since the start day
       var daysSinceStartDay = today.getDay() - this.startDay;
       // add 7 to avoid negative when counting backwards past 0 (Sunday) in the week
-      if (daysSinceStartDay < 0) { daysSinceStartDay =+ 7 }
+      if (daysSinceStartDay < 0) { daysSinceStartDay =+ 7; }
       // Offset by 1 so the query is inclusive
-      startDate = today.getDate() - daysSinceStartDay - 1;
+      var startDate = today.getDate() - daysSinceStartDay - 1;
       return new Date( today.setDate(startDate) );
     },
 

--- a/app.js
+++ b/app.js
@@ -44,10 +44,10 @@
     },
 
     init: function() {
-      // Validation for start day. Defaults to 0
+      // Validation for start day setting. Defaults to 1 (Monday).
       this.startDay = this.setting('start_day');
       if (this.startDay < 0 || this.startDay > 6) { this.startDay = 1 }
-      
+
       if ( !this.store('goal') ){
         this.showEnterGoal();
       } else {
@@ -94,16 +94,20 @@
     // Date helpers
 
     getStartDate: function() {
-      var today = new Date(),
-      // Get date of start day by subtracting days since start day
-          daysAfterStartDay = today.getDay() - this.startDay;
-      // Set to 7 to avoid negative when moving backwards past 0 (Sunday) in the week
-      if (daysAfterStartDay < 0) { daysAfterStartDay =+ 7 }
+      var today = new Date();
+      // Get days since start day by counting backwards in the week
+      // E.g., for a Wednesday start day and Today is Friday
+      // (Wednesday is 3 and Friday is 5 when using getDay())
+      // daysSinceStartDay = 5 - 3, i.e., it's been 2 days since the start day
+      var daysSinceStartDay = today.getDay() - this.startDay;
+      // add 7 to avoid negative when counting backwards past 0 (Sunday) in the week
+      if (daysSinceStartDay < 0) { daysSinceStartDay =+ 7 }
       // Offset by 1 so the query is inclusive
-      startDate = today.getDate() - daysAfterStartDay - 1;
+      startDate = today.getDate() - daysSinceStartDay - 1;
       return new Date( today.setDate(startDate) );
     },
 
+    // Return the end date by moving forward one week
     getEndDate: function() {
       var startDate = this.getStartDate(),
           daysInAWeek = 7,

--- a/app.js
+++ b/app.js
@@ -44,6 +44,10 @@
     },
 
     init: function() {
+      // Validation for start day. Defaults to 0
+      this.startDay = this.setting('start_day');
+      if (this.startDay < 0 || this.startDay > 6) { this.startDay = 1 }
+      
       if ( !this.store('goal') ){
         this.showEnterGoal();
       } else {
@@ -91,9 +95,8 @@
 
     getStartDate: function() {
       var today = new Date(),
-          startDay = this.setting('start_day'),
       // Get date of start day by subtracting days since start day
-          daysAfterStartDay = today.getDay() - startDay;
+          daysAfterStartDay = today.getDay() - this.startDay;
       // Set to 7 to avoid negative when moving backwards past 0 (Sunday) in the week
       if (daysAfterStartDay < 0) { daysAfterStartDay =+ 7 }
       // Offset by 1 so the query is inclusive

--- a/app.js
+++ b/app.js
@@ -49,11 +49,10 @@
       } else {
         this.switchTo('loading');
 
-        var today = new Date();
         this.getSolvedTickets(
           this.currentUser().email(),
-          this.getStartDateQuery(today),
-          this.getEndDateQuery(today)
+          this.getStartDateQuery(),
+          this.getEndDateQuery()
         );
       }
     },
@@ -90,30 +89,32 @@
 
     // Date helpers
 
-    getLastSunday: function(d) {
-      d = new Date(d);
-      var day = d.getDay(),
-        diff = d.getDate() - day + (day === 0 ? -7 : 0);
-      return new Date( d.setDate(diff) );
+    getLastSunday: function() {
+      var today = new Date(),
+          sunday = 0,
+          offset = today.getDay() === sunday ? -7 : 0,
+          startDate = today.getDate() - today.getDay() + offset;
+      return new Date( today.setDate(startDate) );
     },
 
-    getUpcomingMonday: function(d) {
-      d = new Date(d);
-      var day = d.getDay(),
-        diff = d.getDate() - day + (day === 0 ? 1 : 8);
-      return new Date( d.setDate(diff) );
+    getUpcomingMonday: function() {
+      var today = new Date(),
+          sunday = 0,
+          offset = today.getDay() === sunday ? 1 : 8,
+          endDate = today.getDate() - today.getDay() + offset;
+      return new Date( today.setDate(endDate) );
     },
 
     getDateQuery: function(d) {
       return ( d.getFullYear() + "-" + ( d.getMonth() + 1 ) + "-" + d.getDate() );
     },
 
-    getStartDateQuery: function(d) {
-      return this.getDateQuery( this.getLastSunday(d) );
+    getStartDateQuery: function() {
+      return this.getDateQuery( this.getLastSunday() );
     },
 
-    getEndDateQuery: function(d) {
-      return this.getDateQuery( this.getUpcomingMonday(d) );
+    getEndDateQuery: function() {
+      return this.getDateQuery( this.getUpcomingMonday() );
     }
   };
 }());

--- a/app.js
+++ b/app.js
@@ -89,20 +89,24 @@
 
     // Date helpers
 
-    getLastSunday: function() {
+    getStartDate: function() {
       var today = new Date(),
-          sunday = 0,
-          offset = today.getDay() === sunday ? -7 : 0,
-          startDate = today.getDate() - today.getDay() + offset;
+          startDay = this.setting('start_day'),
+      // Get date of start day by subtracting days since start day
+          daysAfterStartDay = today.getDay() - startDay;
+      // Set to 7 to avoid negative when moving backwards past 0 (Sunday) in the week
+      if (daysAfterStartDay < 0) { daysAfterStartDay =+ 7 }
+      // Offset by 1 so the query is inclusive
+      startDate = today.getDate() - daysAfterStartDay - 1;
       return new Date( today.setDate(startDate) );
     },
 
-    getUpcomingMonday: function() {
-      var today = new Date(),
-          sunday = 0,
-          offset = today.getDay() === sunday ? 1 : 8,
-          endDate = today.getDate() - today.getDay() + offset;
-      return new Date( today.setDate(endDate) );
+    getEndDate: function() {
+      var startDate = this.getStartDate(),
+          daysInAWeek = 7,
+          // Offset by 1 so the query is inclusive
+          endDate = startDate.getDate() + daysInAWeek + 1;
+      return new Date( startDate.setDate(endDate) );
     },
 
     getDateQuery: function(d) {
@@ -110,11 +114,11 @@
     },
 
     getStartDateQuery: function() {
-      return this.getDateQuery( this.getLastSunday() );
+      return this.getDateQuery( this.getStartDate() );
     },
 
     getEndDateQuery: function() {
-      return this.getDateQuery( this.getUpcomingMonday() );
+      return this.getDateQuery( this.getEndDate() );
     }
   };
 }());

--- a/manifest.json
+++ b/manifest.json
@@ -9,5 +9,12 @@
   "private": false,
   "location": "ticket_sidebar",
   "version": "0.1.2",
-  "frameworkVersion": "1.0"
+  "frameworkVersion": "1.0",
+  "parameters": [
+    {
+      "name": "start_day",
+      "type": "number",
+      "required": true
+    }
+  ]
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1,6 +1,9 @@
 {
   "app": {
     "description":  "Progress bar showing solved tickets for agents.",
-    "name":         "Progress Bar"
+    "name":         "Progress Bar",
+    "parameters": {
+      "start_day": { "label": "First day of week (as a single-digit number)", "helpText": "1 = Monday, 2 = Tuesday...6 = Saturday. Defaults to Monday. Entering a number higher than 6 or less than 1 will cause the app to default to Monday."}
+    }
   }
 }


### PR DESCRIPTION
https://github.com/jpalmieri/zendesk-progress-bar/issues/10

Allows admin to set the start day of the work week in the app's settings. The setting is available in the app settings and will affect all users of the app.
